### PR TITLE
Remove duplicate Id

### DIFF
--- a/src/MatBlazor/Components/MatSlideToggle/MatSlideToggle.razor
+++ b/src/MatBlazor/Components/MatSlideToggle/MatSlideToggle.razor
@@ -2,7 +2,7 @@
 @typeparam TValue
 @inherits BaseMatSlideToggle<TValue>
 
-<div class="@ClassMapper.AsString()" style="@StyleMapper.AsString()" @ref="Ref"  @attributes="Attributes" Id="@Id">
+<div class="@ClassMapper.AsString()" style="@StyleMapper.AsString()" @ref="Ref"  @attributes="Attributes">
     <div class="mdc-switch__track"></div>
     <div class="mdc-switch__thumb-underlay">
         <div class="mdc-switch__thumb">


### PR DESCRIPTION
The MatSlideToggle component contains a duplicate id which is breaking accessibility.